### PR TITLE
feat : modify FMODStudioModule.cpp to be able to successfully compile on Mac

### DIFF
--- a/Plugins/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
+++ b/Plugins/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
@@ -719,7 +719,8 @@ void FFMODStudioModule::CreateStudioSystem(EFMODSystemContext::Type Type)
 
     if (!Settings.StudioBankKey.IsEmpty())
     {
-        advStudioSettings.encryptionkey = TCHAR_TO_UTF8(*Settings.StudioBankKey);
+        FTCHARToUTF8 Utf8Key(*Settings.StudioBankKey);
+        advStudioSettings.encryptionkey = Utf8Key.Get();
     }
 
     verifyfmod(StudioSystem[Type]->setAdvancedSettings(&advStudioSettings));


### PR DESCRIPTION
Léger changement dans FMODStudioModule.cpp sans quoi le projet ne peut pas être compilé sur Mac.

Est-ce que ça marche bien comme ça sur Windows ?